### PR TITLE
Replace Swift._fromWellFormedCodeUnitSequence

### DIFF
--- a/Sources/IPAddress/IPv6Address.swift
+++ b/Sources/IPAddress/IPv6Address.swift
@@ -14,8 +14,6 @@
 // limitations under the License.
 //
 
-import struct Foundation.Data
-
 // Use lookup tables to massively improve the performance of converting IP addresses to strings.
 fileprivate let lut = ["00","01","02","03","04","05","06","07","08","09","0a","0b","0c","0d","0e","0f",
                        "10","11","12","13","14","15","16","17","18","19","1a","1b","1c","1d","1e","1f",
@@ -439,7 +437,7 @@ public struct IPv6Address: LosslessStringConvertible, Equatable {
         }
         
         // return String._fromWellFormedCodeUnitSequence(UTF8.self, input: out.prefix(ptr))
-        return String(decoding: Data(bytes: Array(out.prefix(ptr))), as: UTF8.self)
+        return String(decoding: out.prefix(ptr), as: UTF8.self)
     }
     
     /// Returns a quad of 32-bit unsigned ints representing the IP address.

--- a/Sources/IPAddress/IPv6Address.swift
+++ b/Sources/IPAddress/IPv6Address.swift
@@ -14,6 +14,8 @@
 // limitations under the License.
 //
 
+import struct Foundation.Data
+
 // Use lookup tables to massively improve the performance of converting IP addresses to strings.
 fileprivate let lut = ["00","01","02","03","04","05","06","07","08","09","0a","0b","0c","0d","0e","0f",
                        "10","11","12","13","14","15","16","17","18","19","1a","1b","1c","1d","1e","1f",
@@ -436,7 +438,8 @@ public struct IPv6Address: LosslessStringConvertible, Equatable {
             }
         }
         
-        return String._fromWellFormedCodeUnitSequence(UTF8.self, input: out.prefix(ptr))
+        // return String._fromWellFormedCodeUnitSequence(UTF8.self, input: out.prefix(ptr))
+        return String(decoding: Data(bytes: Array(out.prefix(ptr))), as: UTF8.self)
     }
     
     /// Returns a quad of 32-bit unsigned ints representing the IP address.


### PR DESCRIPTION
Hi,

Because it's a private function, and cannot found in 4.1.2
