### PR TITLE
Fix Swift Package Manager

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version: 5.5
 //
 // Copyright © Andrew Dunn, 2017
 //
@@ -18,15 +19,22 @@ import PackageDescription
 
 let package = Package(
     name: "IPAddress",
+    dependencies: [],
     targets: [
-        Target(
-            name: "IPAddressBenchmarks",
-            dependencies: [
-                "IPAddress"
-            ]),
-        Target(
+        .target(
             name: "IPAddress"
         ),
-    ],
-    dependencies: []
+        .executableTarget(
+            name: "IPAddressBenchmarks",
+            dependencies: [
+                .target(name: "IPAddress")
+            ]
+        ),
+        .testTarget(
+            name: "IPAddressTests",
+            dependencies: [
+                .target(name: "IPAddress")
+            ]
+        )
+    ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,12 @@ import PackageDescription
 
 let package = Package(
     name: "IPAddress",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "IPAddress",
+            targets: ["IPAddress"]),
+    ],
     dependencies: [],
     targets: [
         .target(

--- a/Sources/IPAddress/IPv4Address.swift
+++ b/Sources/IPAddress/IPv4Address.swift
@@ -14,9 +14,9 @@
 // limitations under the License.
 //
 
-fileprivate let zero = UnicodeScalar("0")!
-fileprivate let nine = UnicodeScalar("9")!
-fileprivate let dot = UnicodeScalar(".")!
+fileprivate let zero = UnicodeScalar("0")
+fileprivate let nine = UnicodeScalar("9")
+fileprivate let dot = UnicodeScalar(".")
 
 // Use lookup tables to massively improve the performance of converting IP addresses to strings.
 fileprivate let firstQuad = [  "0",  "1",  "2",  "3",  "4",  "5",  "6",  "7",  "8",  "9",
@@ -317,7 +317,7 @@ public struct IPv4Address: LosslessStringConvertible, Equatable {
 /// Extracts an integer representation of the given IPv4 address in network-byte
 /// order.
 public extension UInt32 {
-    public init (fromIPv4Address ip: IPv4Address) {
+    init (fromIPv4Address ip: IPv4Address) {
         self = ip.value
     }
 }


### PR DESCRIPTION
The package as is no longer works with the Swift Package Manger since it is missing the 
```swift
// swift-tools-version: 
```
flag at the beginning of the `Package.swift` file.

This pull request fixes this issue and resolves all errors when compiling with a newer Swift version. 

All tests pass.