### PR TITLE
CIDR membership, IPv6 parser hardening, and dual-stack classification

### DIFF
--- a/Sources/IPAddress/IPv4Address.swift
+++ b/Sources/IPAddress/IPv4Address.swift
@@ -79,10 +79,10 @@ fileprivate let latterQuads = [  ".0",  ".1",  ".2",  ".3",  ".4",  ".5",  ".6",
 ///
 /// - Author: Andrew Dunn.
 ///
-public struct IPv4Address: LosslessStringConvertible, Equatable {
+public struct IPv4Address: LosslessStringConvertible, Hashable {
     // Store the value in an array to enable simple typecasting to an array of
     // [UInt8] values.
-    fileprivate let value: UInt32;
+    fileprivate let value: UInt32
     
     /// Initialises a new instance with all zeroes.
     public init () {
@@ -102,34 +102,34 @@ public struct IPv4Address: LosslessStringConvertible, Equatable {
     
     /// Initialises a new instance with an array of octets.
     ///
-    /// - Parameter array: An array of octets that make up the parts of an IP
-    ///                    address.
+    /// - Parameter octets: An array of octets that make up the parts of an IP
+    ///                     address.
     ///
     /// - Note: If the number of elements in the array is not equal to *4*,
     ///         the behaviour is undefined.
-    public init (fromOctets array: [UInt8]) {
-        assert(array.count == 4)
-        value = array.withUnsafeBytes({ (p) -> UInt32 in
+    public init(_ octets: [UInt8]) {
+        assert(octets.count == 4)
+        value = octets.withUnsafeBytes({ (p) -> UInt32 in
             return p.load(as: UInt32.self)
         })
     }
-    
-    /// Intialises a new instance with an integer representation of an IP
+
+    /// Initialises a new instance with an integer representation of an IP
     /// address in network-byte order.
     ///
     /// - Parameter uint: An integer representation of an IP address in
     ///                   network-byte order.
-    public init (fromUInt32 uint: UInt32) {
+    public init(_ uint: UInt32) {
         value = uint
     }
-    
-    /// Intialises a new instance from a string representaion of an IPv4
+
+    /// Initialises a new instance from a string representation of an IPv4
     /// address.
     ///
     /// - Parameter str: A string representation of an IPv4 address. If the
     ///                  string is anything other than an IPv4 address, `nil`
     ///                  will be returned instead.
-    public init? (_ str: String) {
+    public init?(_ str: String) {
         var shiftedDistance = UInt32(0)
         var currentValue = UInt32(0)
         var currentLength = 0
@@ -259,7 +259,7 @@ public struct IPv4Address: LosslessStringConvertible, Equatable {
     public var isBroadcast: Bool {
         return value == 0xFFFFFFFF
     }
-    
+
     /// Returns true if the IP address is in a block reserved for the purposes
     /// of having example IP addresses in written documentation.
     public var isDocumentation: Bool {
@@ -267,7 +267,34 @@ public struct IPv4Address: LosslessStringConvertible, Equatable {
             (value & 0x00FFFFFF) == 0x006433C6 ||
             (value & 0x00FFFFFF) == 0x007100CB
     }
+
+    /// Returns true if the IP address is included in the given CIDR range.
+    ///
+    /// - Parameter cidr: The CIDR range to test membership in.
+    /// - Returns: True if the IP address is within the range, false otherwise.
+    public func isIncluded(in cidr: IPv4CIDR) -> Bool {
+        return (value & cidr.mask) == cidr.maskedNetwork
+    }
+
+    /// Returns true if the IP address is included in the given CIDR range.
+    ///
+    /// - Parameter range: A string representation of a CIDR range (e.g., "192.168.0.0/16").
+    /// - Returns: True if the IP address is within the range, false otherwise.
+    public func isIncluded(in range: String) -> Bool {
+        guard let cidr = IPv4CIDR(range) else { return false }
+        return isIncluded(in: cidr)
+    }
     
+    // MARK: - Deprecated API
+
+    @available(*, deprecated, renamed: "init(_:)")
+    public init(fromOctets octets: [UInt8]) { self.init(octets) }
+
+    @available(*, deprecated, renamed: "init(_:)")
+    public init(fromUInt32 uint: UInt32) { self.init(uint) }
+
+    // MARK: -
+
     /// Returns a string representation of the IP address.
     public var description: String {
         let o0 = Int(value & 0xFF)
@@ -293,7 +320,7 @@ public struct IPv4Address: LosslessStringConvertible, Equatable {
     public static var loopback: IPv4Address {
         struct Static {
             static let loopbackAddress =
-                IPv4Address.init(fromUInt32: 0x0100007F)
+                IPv4Address(0x0100007F)
         }
         return Static.loopbackAddress
     }
@@ -303,7 +330,7 @@ public struct IPv4Address: LosslessStringConvertible, Equatable {
     public static var broadcast: IPv4Address {
         struct Static {
             static let broadcastAddress =
-                IPv4Address.init(fromUInt32: 0xFFFFFFFF)
+                IPv4Address(0xFFFFFFFF)
         }
         return Static.broadcastAddress
     }
@@ -314,10 +341,48 @@ public struct IPv4Address: LosslessStringConvertible, Equatable {
     }
 }
 
+/// Represents an IPv4 CIDR range.
+///
+/// Pre-computes the mask and masked network address at construction time so
+/// membership tests (`IPv4Address.isIncluded(in:)`) are a single bitmask-and-compare
+/// with no parsing or allocation.
+public struct IPv4CIDR: Hashable {
+    // Stored in the same little-endian layout as IPv4Address.value.
+    fileprivate let maskedNetwork: UInt32
+    fileprivate let mask: UInt32
+
+    /// Initialises a new instance from a network address and prefix length.
+    ///
+    /// - Parameters:
+    ///   - network: The network address (host bits are ignored).
+    ///   - prefix: The prefix length (0–32). Returns `nil` if out of range.
+    public init?(network: IPv4Address, prefix: UInt32) {
+        guard prefix <= 32 else { return nil }
+        // Build the mask in network byte order then byte-swap to match the
+        // little-endian internal representation.
+        let mask: UInt32 = prefix == 0 ? 0 : (UInt32.max << (32 - prefix)).byteSwapped
+        self.mask = mask
+        self.maskedNetwork = network.value & mask
+    }
+
+    /// Initialises a new instance from a CIDR string (e.g. "192.168.0.0/16").
+    /// Returns `nil` if the string is not a valid CIDR range.
+    public init?(_ description: String) {
+        let components = description.split(separator: "/")
+        guard components.count == 2,
+              let network = IPv4Address(String(components[0])),
+              let prefix = UInt32(components[1]) else { return nil }
+        self.init(network: network, prefix: prefix)
+    }
+}
+
 /// Extracts an integer representation of the given IPv4 address in network-byte
 /// order.
 public extension UInt32 {
-    init (fromIPv4Address ip: IPv4Address) {
+    init(_ ip: IPv4Address) {
         self = ip.value
     }
+
+    @available(*, deprecated, renamed: "init(_:)")
+    init(fromIPv4Address ip: IPv4Address) { self.init(ip) }
 }

--- a/Sources/IPAddress/IPv6Address.swift
+++ b/Sources/IPAddress/IPv6Address.swift
@@ -48,16 +48,21 @@ fileprivate let F: UInt8 = 0x46
 ///
 /// - Author: Andrew Dunn.
 ///
-public struct IPv6Address: LosslessStringConvertible, Equatable {
+public struct IPv6Address: LosslessStringConvertible, Hashable {
     fileprivate let high, low: UInt64
-    
-    public static func ==(lhs: IPv6Address, rhs: IPv6Address) -> Bool {
-        return  lhs.high == rhs.high && lhs.low == rhs.low
+
+    public static func == (lhs: IPv6Address, rhs: IPv6Address) -> Bool {
+        return lhs.high == rhs.high && lhs.low == rhs.low
     }
-    
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(high)
+        hasher.combine(low)
+    }
+
     public init() {
-        low = 0;
-        high = 0;
+        low = 0
+        high = 0
     }
     
     /// Initialises a new instance with the given values.
@@ -79,7 +84,7 @@ public struct IPv6Address: LosslessStringConvertible, Equatable {
               | (UInt64(g.bigEndian) << 32) | (UInt64(h.bigEndian) << 48)
     }
     
-    /// Intialises a new instance from a string representaion of an IPv6
+    /// Initialises a new instance from a string representation of an IPv6
     /// address.
     ///
     /// - Parameter str: A string representation of an IPv6 address. If the
@@ -307,7 +312,25 @@ public struct IPv6Address: LosslessStringConvertible, Equatable {
     public var isDocumentation: Bool {
         return (high & 0xFFFF_FFFF) == 0xb80d_0120
     }
-    
+
+    /// Returns true if the IP address is included in the given CIDR range.
+    ///
+    /// - Parameter cidr: The CIDR range to test membership in.
+    /// - Returns: True if the IP address is within the range, false otherwise.
+    public func isIncluded(in cidr: IPv6CIDR) -> Bool {
+        return (high & cidr.highMask) == cidr.maskedNetworkHigh &&
+               (low  & cidr.lowMask)  == cidr.maskedNetworkLow
+    }
+
+    /// Returns true if the IP address is included in the given CIDR range.
+    ///
+    /// - Parameter range: A string representation of a CIDR range (e.g., "2001:db8::/32").
+    /// - Returns: True if the IP address is within the range, false otherwise.
+    public func isIncluded(in range: String) -> Bool {
+        guard let cidr = IPv6CIDR(range) else { return false }
+        return isIncluded(in: cidr)
+    }
+
     /// Returns a string representation of the IP address. Will display IPv4 compatible/mapped addresses
     /// correctly, and will truncate zeroes when possible.
     public var description: String {
@@ -333,7 +356,7 @@ public struct IPv6Address: LosslessStringConvertible, Equatable {
             let ipv4Check = low & 0x0000_0000_FFFF_FFFF
             if (ipv4Check == 0 || ipv4Check == 0xFFFF_0000) {
                 // Use dotted quads to represent the IPv4 part.
-                let ipv4 = IPv4Address(fromUInt32: UInt32(low >> 32))
+                let ipv4 = IPv4Address(UInt32(low >> 32))
                 if (ipv4Check == 0) {
                     return "::\(ipv4.description)"
                 }
@@ -473,5 +496,53 @@ public struct IPv6Address: LosslessStringConvertible, Equatable {
             static let loopbackAddress = IPv6Address.init(parts: 0, 0, 0, 0, 0, 0, 0, 1)
         }
         return Static.loopbackAddress
+    }
+}
+
+/// Represents an IPv6 CIDR range.
+///
+/// Pre-computes the masks and masked network halves at construction time so
+/// membership tests (`IPv6Address.isIncluded(in:)`) are two bitmask-and-compare
+/// operations with no parsing or allocation.
+public struct IPv6CIDR: Hashable {
+    // Stored in the same little-endian layout as IPv6Address.high / .low.
+    fileprivate let maskedNetworkHigh: UInt64
+    fileprivate let maskedNetworkLow: UInt64
+    fileprivate let highMask: UInt64
+    fileprivate let lowMask: UInt64
+
+    /// Initialises a new instance from a network address and prefix length.
+    ///
+    /// - Parameters:
+    ///   - network: The network address (host bits are ignored).
+    ///   - prefix: The prefix length (0–128). Returns `nil` if out of range.
+    public init?(network: IPv6Address, prefix: UInt32) {
+        guard prefix <= 128 else { return nil }
+        let highBits = min(prefix, 64)
+        let lowBits = prefix > 64 ? prefix - 64 : 0
+
+        // Build masks in network byte order then byte-swap to match the
+        // little-endian internal representation of `high` and `low`.
+        let highMask: UInt64 = highBits == 0 ? 0
+                             : highBits == 64 ? UInt64.max
+                             : (UInt64.max << (64 - highBits)).byteSwapped
+        let lowMask: UInt64  = lowBits == 0 ? 0
+                             : lowBits == 64 ? UInt64.max
+                             : (UInt64.max << (64 - lowBits)).byteSwapped
+
+        self.highMask = highMask
+        self.lowMask = lowMask
+        self.maskedNetworkHigh = network.high & highMask
+        self.maskedNetworkLow = network.low & lowMask
+    }
+
+    /// Initialises a new instance from a CIDR string (e.g. "2001:db8::/32").
+    /// Returns `nil` if the string is not a valid CIDR range.
+    public init?(_ description: String) {
+        let components = description.split(separator: "/")
+        guard components.count == 2,
+              let network = IPv6Address(String(components[0])),
+              let prefix = UInt32(components[1]) else { return nil }
+        self.init(network: network, prefix: prefix)
     }
 }

--- a/Sources/IPAddress/IPv6Address.swift
+++ b/Sources/IPAddress/IPv6Address.swift
@@ -143,10 +143,10 @@ public struct IPv6Address: LosslessStringConvertible, Hashable {
                 // The first part of the quad needs to be re-calculated, as it was originally parsed as hex.
                 if !parsingQuad {
                     var newV: UInt16 = 0
-                    if currentValue > 0x100 {
+                    if currentValue >= 0x100 {
                         newV += ((currentValue & 0xF00) >> 8) * 100
                     }
-                    if currentValue > 0x10 {
+                    if currentValue >= 0x10 {
                         newV += ((currentValue & 0xF0) >> 4) * 10
                     }
                     newV += currentValue & 0xF
@@ -198,7 +198,7 @@ public struct IPv6Address: LosslessStringConvertible, Hashable {
                 currentValue = 0
                 currentLength = 0
             } else {
-                break
+                return nil
             }
         }
         if (parsingQuad) {
@@ -267,35 +267,58 @@ public struct IPv6Address: LosslessStringConvertible, Hashable {
         low = lo
     }
     
+    /// If this address is the IPv4-mapped form **(::ffff:X.X.X.X)**, returns the
+    /// embedded IPv4 address; otherwise `nil`. Used by the classification
+    /// predicates so that a dual-stack socket's eventual destination is
+    /// considered when deciding whether an address is loopback, private, etc.
+    private var ipv4Mapped: IPv4Address? {
+        guard high == 0 && (low & 0x0000_0000_FFFF_FFFF) == 0x0000_0000_FFFF_0000
+            else { return nil }
+        return IPv4Address(UInt32(low >> 32))
+    }
+
     /// Returns `true` if the IP address is an unspecified, if you listen on
     /// this address, your socket will listen on all addresses available.
     ///
-    /// - Note: Equivalent to checking if the IP address is equal to
-    ///         **::**.
+    /// - Note: Equivalent to checking if the IP address is equal to **::**
+    ///         or its IPv4-mapped form **::ffff:0.0.0.0**.
     public var isUnspecified: Bool {
-        return high == 0 && low == 0
+        if high == 0 && low == 0 { return true }
+        return ipv4Mapped?.isUnspecified ?? false
     }
 
     /// Returns `true` if the IP address is a loopback address.
     ///
-    /// - Note: Equivalent to checking if the IP address is **::1**.
+    /// - Note: Matches **::1** and the IPv4-mapped loopback block
+    ///         **::ffff:127.0.0.0/104**.
     public var isLoopback: Bool {
-        return high == 0 && low == 0x0100_0000_0000_0000
+        if high == 0 && low == 0x0100_0000_0000_0000 { return true }
+        return ipv4Mapped?.isLoopback ?? false
     }
-    
+
     /// Returns `true` if the IP address is a global unicast address **(2000::/3)**.
     public var isUnicastGlobal: Bool {
         return (high & 0xE0) == 0x20
     }
-    
+
     /// Returns `true` if the IP address is a unique local address **(fc00::/7)**.
+    ///
+    /// - Note: Also returns `true` for IPv4-mapped RFC 1918 addresses so that
+    ///         a dual-stack SSRF filter rejecting "private" addresses catches
+    ///         e.g. **::ffff:10.0.0.1**.
     public var isUnicastUniqueLocal: Bool {
-        return (high & 0xFE) == 0xFC
+        if (high & 0xFE) == 0xFC { return true }
+        return ipv4Mapped?.isPrivate ?? false
     }
-    
+
     /// Returns `true` if the IP address is a unicast link-local address **(fe80::/10)**.
+    ///
+    /// - Note: Also returns `true` for the IPv4-mapped form of
+    ///         **169.254.0.0/16** so that dual-stack filters catch e.g.
+    ///         **::ffff:169.254.169.254** (AWS instance metadata).
     public var isUnicastLinkLocal: Bool {
-        return (high & 0xC0FF) == 0x80FE
+        if (high & 0xC0FF) == 0x80FE { return true }
+        return ipv4Mapped?.isLinkLocal ?? false
     }
     
     /// Returns `true` if the IP address is a (deprecated) unicast site-local address **(fec0::/10)**.

--- a/Tests/IPAddressTests/IPv4AddressTests.swift
+++ b/Tests/IPAddressTests/IPv4AddressTests.swift
@@ -374,7 +374,32 @@ class IPv4AddressTests: XCTestCase {
         address = IPv4Address(parts: 203,0,113,0)
         XCTAssertFalse(address.isGlobal)
     }
-    
+
+    /// `isGlobal` is documented as "globally-routable" — the obvious primitive
+    /// for SSRF egress filtering — but its negation list omits several RFC 6890
+    /// non-globally-routable ranges. Each assertion below should return false
+    /// once the bug is fixed.
+    func testIsGlobalNonRoutableRanges() {
+        // 224.0.0.0/4 multicast. SSDP / mDNS / all-hosts are LAN-only.
+        XCTAssertFalse(IPv4Address(parts: 239, 255, 255, 250).isGlobal)
+        XCTAssertFalse(IPv4Address(parts: 224, 0, 0, 251).isGlobal)
+        XCTAssertFalse(IPv4Address(parts: 224, 0, 0, 1).isGlobal)
+        // 100.64.0.0/10 — carrier-grade NAT.
+        XCTAssertFalse(IPv4Address(parts: 100, 64, 0, 1).isGlobal)
+        XCTAssertFalse(IPv4Address(parts: 100, 127, 255, 254).isGlobal)
+        // 240.0.0.0/4 reserved (RFC 1112).
+        XCTAssertFalse(IPv4Address(parts: 240, 0, 0, 1).isGlobal)
+        XCTAssertFalse(IPv4Address(parts: 250, 100, 50, 25).isGlobal)
+        // 0.0.0.0/8 "this network" (RFC 1122).
+        XCTAssertFalse(IPv4Address(parts: 0, 1, 2, 3).isGlobal)
+        XCTAssertFalse(IPv4Address(parts: 0, 255, 255, 254).isGlobal)
+        // 198.18.0.0/15 benchmarking (RFC 2544).
+        XCTAssertFalse(IPv4Address(parts: 198, 18, 0, 1).isGlobal)
+        XCTAssertFalse(IPv4Address(parts: 198, 19, 255, 254).isGlobal)
+        // 192.0.0.0/24 IETF protocol assignments.
+        XCTAssertFalse(IPv4Address(parts: 192, 0, 0, 1).isGlobal)
+    }
+
     /// Test for multicast address detection.
     func testIsMulticast() {
         var address = IPv4Address(parts: 223,0,0,0)
@@ -537,33 +562,54 @@ class IPv4AddressTests: XCTestCase {
     func testValue() {
         var address: IPv4Address
         address = IPv4Address()
-        XCTAssertEqual(UInt32(address), 0x00000000)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
         address = IPv4Address(parts: 0,0,0,0)
-        XCTAssertEqual(UInt32(address), 0x00000000)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
+        address = IPv4Address(fromOctets: [0,0,0,0])
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
+        address = IPv4Address(fromUInt32: 0x00000000)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
+        address = IPv4Address(parts: 255,255,255,255)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xFFFFFFFF)
+        address = IPv4Address(fromOctets: [255,255,255,255])
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xFFFFFFFF)
+        address = IPv4Address(fromUInt32: 0xFFFFFFFF)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xFFFFFFFF)
+        address = IPv4Address(parts: 178,152,71,53)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x354798B2)
+        address = IPv4Address(fromOctets: [178,152,71,53])
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x354798B2)
+        address = IPv4Address(fromUInt32: 0x354798B2)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x354798B2)
+        address = IPv4Address(parts: 61,105,180,185)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xB9B4693D)
+        address = IPv4Address(fromOctets: [61,105,180,185])
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xB9B4693D)
+        address = IPv4Address(fromUInt32: 0xB9B4693D)
+        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xB9B4693D)
+    }
+
+    /// Mirrors `testValue` but exercises the unlabeled `init(_:)` overloads.
+    func testValueUnlabeledInits() {
+        var address: IPv4Address
         address = IPv4Address([0,0,0,0])
         XCTAssertEqual(UInt32(address), 0x00000000)
         address = IPv4Address(0x00000000)
         XCTAssertEqual(UInt32(address), 0x00000000)
-        address = IPv4Address(parts: 255,255,255,255)
-        XCTAssertEqual(UInt32(address), 0xFFFFFFFF)
         address = IPv4Address([255,255,255,255])
         XCTAssertEqual(UInt32(address), 0xFFFFFFFF)
         address = IPv4Address(0xFFFFFFFF)
         XCTAssertEqual(UInt32(address), 0xFFFFFFFF)
-        address = IPv4Address(parts: 178,152,71,53)
-        XCTAssertEqual(UInt32(address), 0x354798B2)
         address = IPv4Address([178,152,71,53])
         XCTAssertEqual(UInt32(address), 0x354798B2)
         address = IPv4Address(0x354798B2)
         XCTAssertEqual(UInt32(address), 0x354798B2)
-        address = IPv4Address(parts: 61,105,180,185)
-        XCTAssertEqual(UInt32(address), 0xB9B4693D)
         address = IPv4Address([61,105,180,185])
         XCTAssertEqual(UInt32(address), 0xB9B4693D)
         address = IPv4Address(0xB9B4693D)
         XCTAssertEqual(UInt32(address), 0xB9B4693D)
     }
-    
+
     /// Test that the octet array extraction works as expected.
     func testOctets() {
         var address: IPv4Address
@@ -749,11 +795,13 @@ class IPv4AddressTests: XCTestCase {
         ("testIsPrivate",          testIsPrivate),
         ("testIsLinkLocal",        testIsLinkLocal),
         ("testIsGlobal",           testIsGlobal),
+        ("testIsGlobalNonRoutableRanges", testIsGlobalNonRoutableRanges),
         ("testIsMulticast",        testIsMulticast),
         ("testIsBroadcast",        testIsBroadcast),
         ("testIsDocumentation",    testIsDocumentation),
         ("testStaticValues",       testStaticValues),
         ("testValue",              testValue),
+        ("testValueUnlabeledInits", testValueUnlabeledInits),
         ("testOctets",             testOctets),
         ("testStringConversion",   testStringConversion),
         ("testEqualityOperators",  testEqualityOperators),

--- a/Tests/IPAddressTests/IPv4AddressTests.swift
+++ b/Tests/IPAddressTests/IPv4AddressTests.swift
@@ -443,7 +443,6 @@ class IPv4AddressTests: XCTestCase {
         XCTAssertFalse(address.isDocumentation)
         address = IPv4Address(parts: 192,0,2,0)
         XCTAssertTrue(address.isDocumentation)
-        
         // TEST-NET-2.
         //
         // 198.51.100.0/24
@@ -461,7 +460,6 @@ class IPv4AddressTests: XCTestCase {
         XCTAssertFalse(address.isDocumentation)
         address = IPv4Address(parts: 198,51,100,0)
         XCTAssertTrue(address.isDocumentation)
-        
         // TEST-NET-3.
         //
         // 203.0.113.0/24
@@ -480,6 +478,50 @@ class IPv4AddressTests: XCTestCase {
         address = IPv4Address(parts: 203,0,113,0)
         XCTAssertTrue(address.isDocumentation)
     }
+
+    /// Test for CIDR range inclusion.
+    func testIncludedIn() {
+        let address = IPv4Address(parts: 171,245,48,40)
+        // Non-octet prefix length (/20).
+        XCTAssertTrue(address.isIncluded(in:"171.245.48.0/20"))
+        XCTAssertFalse(address.isIncluded(in:"171.245.64.0/20"))
+        // Exact match (/32).
+        XCTAssertFalse(address.isIncluded(in:"171.245.48.0/32"))
+        XCTAssertTrue(address.isIncluded(in:"171.245.48.40/32"))
+        // Wider ranges.
+        XCTAssertTrue(address.isIncluded(in:"171.245.0.0/16"))
+        XCTAssertTrue(address.isIncluded(in:"171.0.0.0/8"))
+        // Match-all range (/0).
+        XCTAssertTrue(address.isIncluded(in:"0.0.0.0/0"))
+        // Invalid input.
+        XCTAssertFalse(address.isIncluded(in:"invalid range"))
+        XCTAssertFalse(address.isIncluded(in:"171.245.48.0/33"))
+    }
+
+    /// Test IPv4CIDR construction and reuse.
+    func testIPv4CIDR() {
+        // Valid initialisers.
+        XCTAssertNotNil(IPv4CIDR("192.168.0.0/16"))
+        XCTAssertNotNil(IPv4CIDR(network: IPv4Address(parts: 192,168,0,0), prefix: 16))
+        // Invalid initialisers.
+        XCTAssertNil(IPv4CIDR("192.168.0.0/33"))
+        XCTAssertNil(IPv4CIDR("not a cidr"))
+        // Host bits in the network address are ignored.
+        let cidrFromString = IPv4CIDR("192.168.1.0/16")!
+        let cidrFromParts  = IPv4CIDR(network: IPv4Address(parts: 192,168,1,0), prefix: 16)!
+        XCTAssertEqual(cidrFromString, cidrFromParts)
+        // Typed overload produces identical results to the string overload.
+        let cidr20 = IPv4CIDR("171.245.48.0/20")!
+        let address = IPv4Address(parts: 171,245,48,40)
+        XCTAssertTrue(address.isIncluded(in:cidr20))
+        XCTAssertFalse(IPv4Address(parts: 171,245,64,0).isIncluded(in:cidr20))
+        // /0 matches everything; /32 is exact.
+        let all  = IPv4CIDR(network: IPv4Address(parts: 0,0,0,0), prefix: 0)!
+        let exact = IPv4CIDR(network: address, prefix: 32)!
+        XCTAssertTrue(address.isIncluded(in:all))
+        XCTAssertTrue(address.isIncluded(in:exact))
+        XCTAssertFalse(IPv4Address(parts: 0,0,0,0).isIncluded(in:exact))
+    }
     
     /// Test that predefined addresses are correct.
     func testStaticValues() {
@@ -495,31 +537,31 @@ class IPv4AddressTests: XCTestCase {
     func testValue() {
         var address: IPv4Address
         address = IPv4Address()
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
+        XCTAssertEqual(UInt32(address), 0x00000000)
         address = IPv4Address(parts: 0,0,0,0)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
-        address = IPv4Address(fromOctets: [0,0,0,0])
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
-        address = IPv4Address(fromUInt32: 0x00000000)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x00000000)
+        XCTAssertEqual(UInt32(address), 0x00000000)
+        address = IPv4Address([0,0,0,0])
+        XCTAssertEqual(UInt32(address), 0x00000000)
+        address = IPv4Address(0x00000000)
+        XCTAssertEqual(UInt32(address), 0x00000000)
         address = IPv4Address(parts: 255,255,255,255)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xFFFFFFFF)
-        address = IPv4Address(fromOctets: [255,255,255,255])
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xFFFFFFFF)
-        address = IPv4Address(fromUInt32: 0xFFFFFFFF)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xFFFFFFFF)
+        XCTAssertEqual(UInt32(address), 0xFFFFFFFF)
+        address = IPv4Address([255,255,255,255])
+        XCTAssertEqual(UInt32(address), 0xFFFFFFFF)
+        address = IPv4Address(0xFFFFFFFF)
+        XCTAssertEqual(UInt32(address), 0xFFFFFFFF)
         address = IPv4Address(parts: 178,152,71,53)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x354798B2)
-        address = IPv4Address(fromOctets: [178,152,71,53])
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x354798B2)
-        address = IPv4Address(fromUInt32: 0x354798B2)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0x354798B2)
+        XCTAssertEqual(UInt32(address), 0x354798B2)
+        address = IPv4Address([178,152,71,53])
+        XCTAssertEqual(UInt32(address), 0x354798B2)
+        address = IPv4Address(0x354798B2)
+        XCTAssertEqual(UInt32(address), 0x354798B2)
         address = IPv4Address(parts: 61,105,180,185)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xB9B4693D)
-        address = IPv4Address(fromOctets: [61,105,180,185])
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xB9B4693D)
-        address = IPv4Address(fromUInt32: 0xB9B4693D)
-        XCTAssertEqual(UInt32(fromIPv4Address: address), 0xB9B4693D)
+        XCTAssertEqual(UInt32(address), 0xB9B4693D)
+        address = IPv4Address([61,105,180,185])
+        XCTAssertEqual(UInt32(address), 0xB9B4693D)
+        address = IPv4Address(0xB9B4693D)
+        XCTAssertEqual(UInt32(address), 0xB9B4693D)
     }
     
     /// Test that the octet array extraction works as expected.
@@ -597,7 +639,7 @@ class IPv4AddressTests: XCTestCase {
         XCTAssertTrue(address1 != address2)
         XCTAssertNotEqual(address1, address2)
         address1 = IPv4Address(parts: 61,105,180,185)
-        address2 = IPv4Address(fromOctets: [61,105,180,185])
+        address2 = IPv4Address([61,105,180,185])
         XCTAssertTrue(address1 == address2)
         XCTAssertFalse(address1 != address2)
         XCTAssertEqual(address1, address2)
@@ -674,7 +716,7 @@ class IPv4AddressTests: XCTestCase {
             }
             return in_addr(
                 s_addr: in_addr_t(
-                    integerLiteral: UInt32(fromIPv4Address: result!)))
+                    integerLiteral: UInt32(result!)))
         }
         
         var ipAddressString = "61.105.180.185"

--- a/Tests/IPAddressTests/IPv6AddressTests.swift
+++ b/Tests/IPAddressTests/IPv6AddressTests.swift
@@ -129,6 +129,55 @@ class IPv6AddressTests: XCTestCase {
                                          0xffff, 0xffff, 0xffff, 0xffff).isDocumentation)
     }
     
+    /// Test for CIDR range inclusion.
+    func testIncludedIn() {
+        let address = IPv6Address(parts: 0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)
+        // Prefix entirely within `high` — /32.
+        XCTAssertTrue(address.isIncluded(in:"2001:db8::/32"))
+        XCTAssertFalse(address.isIncluded(in:"2002::/32"))
+        // Wider prefixes.
+        XCTAssertTrue(address.isIncluded(in:"2001::/16"))
+        // Non-octet prefix length within `high` — /36.
+        XCTAssertTrue(address.isIncluded(in:"2001:db8::/36"))
+        XCTAssertFalse(address.isIncluded(in:"2001:db8:1000::/36"))
+        // Prefix spanning `high` and `low` — /80.
+        XCTAssertTrue(address.isIncluded(in:"2001:db8::/80"))
+        XCTAssertFalse(IPv6Address(parts: 0x2001, 0x0db8, 0, 0, 1, 0, 0, 0).isIncluded(in:"2001:db8::/80"))
+        // Exact match (/128).
+        XCTAssertTrue(address.isIncluded(in:"2001:db8::1/128"))
+        XCTAssertFalse(address.isIncluded(in:"2001:db8::2/128"))
+        // Match-all (/0).
+        XCTAssertTrue(address.isIncluded(in:"::/0"))
+        // Invalid input.
+        XCTAssertFalse(address.isIncluded(in:"invalid range"))
+        XCTAssertFalse(address.isIncluded(in:"2001:db8::/129"))
+    }
+
+    /// Test IPv6CIDR construction and reuse.
+    func testIPv6CIDR() {
+        // Valid initialisers.
+        XCTAssertNotNil(IPv6CIDR("2001:db8::/32"))
+        XCTAssertNotNil(IPv6CIDR(network: IPv6Address(parts: 0x2001, 0x0db8, 0, 0, 0, 0, 0, 0), prefix: 32))
+        // Invalid initialisers.
+        XCTAssertNil(IPv6CIDR("2001:db8::/129"))
+        XCTAssertNil(IPv6CIDR("not a cidr"))
+        // Host bits in the network address are ignored.
+        let cidrFromString = IPv6CIDR("2001:db8::1/32")!
+        let cidrFromParts  = IPv6CIDR(network: IPv6Address(parts: 0x2001, 0x0db8, 0, 0, 0, 0, 0, 1), prefix: 32)!
+        XCTAssertEqual(cidrFromString, cidrFromParts)
+        // Typed overload produces identical results to the string overload.
+        let cidr32 = IPv6CIDR("2001:db8::/32")!
+        let address = IPv6Address(parts: 0x2001, 0x0db8, 0, 0, 0, 0, 0, 1)
+        XCTAssertTrue(address.isIncluded(in:cidr32))
+        XCTAssertFalse(IPv6Address(parts: 0x2002, 0, 0, 0, 0, 0, 0, 0).isIncluded(in:cidr32))
+        // /0 matches everything; /128 is exact.
+        let all   = IPv6CIDR(network: IPv6Address(parts: 0, 0, 0, 0, 0, 0, 0, 0), prefix: 0)!
+        let exact = IPv6CIDR(network: address, prefix: 128)!
+        XCTAssertTrue(address.isIncluded(in:all))
+        XCTAssertTrue(address.isIncluded(in:exact))
+        XCTAssertFalse(IPv6Address(parts: 0, 0, 0, 0, 0, 0, 0, 0).isIncluded(in:exact))
+    }
+
     /// Test that predefined addresses are correct.
     func testStaticValues() {
         XCTAssertTrue(IPv6Address.any.isUnspecified)

--- a/Tests/IPAddressTests/IPv6AddressTests.swift
+++ b/Tests/IPAddressTests/IPv6AddressTests.swift
@@ -50,7 +50,30 @@ class IPv6AddressTests: XCTestCase {
         address = IPv6Address(parts: 0, 0, 0, 0, 0, 0, 0, 0x100)
         XCTAssertFalse(address.isLoopback)
     }
-    
+
+    /// Classification predicates must recognise IPv4-mapped IPv6 addresses
+    /// (`::ffff:X.X.X.X`). A dual-stack SSRF filter that checks both the
+    /// IPv4 and IPv6 predicates is bypassed by the mapped form: the IPv4
+    /// parser rejects it, the IPv6 parser accepts it, and every IPv6
+    /// classification returns false — yet a V4MAPPED socket still connects
+    /// to the embedded IPv4 address.
+    func testIPv4MappedClassification() {
+        // Mapped 127.0.0.0/8 must classify as loopback.
+        XCTAssertTrue(IPv6Address("::ffff:127.0.0.1")!.isLoopback)
+        XCTAssertTrue(IPv6Address("::ffff:127.255.255.254")!.isLoopback)
+        XCTAssertTrue(IPv6Address("::ffff:127.1.2.3")!.isLoopback)
+        // Mapped 0.0.0.0 must classify as unspecified.
+        XCTAssertTrue(IPv6Address("::ffff:0.0.0.0")!.isUnspecified)
+        // RFC 1918 addresses in mapped form must be flagged by some
+        // predicate so a dual-stack filter can reject them. The closest
+        // IPv6 analogue of "private" is unique-local.
+        XCTAssertTrue(IPv6Address("::ffff:10.0.0.1")!.isUnicastUniqueLocal)
+        XCTAssertTrue(IPv6Address("::ffff:172.16.0.1")!.isUnicastUniqueLocal)
+        XCTAssertTrue(IPv6Address("::ffff:192.168.0.1")!.isUnicastUniqueLocal)
+        // 169.254.169.254 — AWS instance metadata — must be flagged.
+        XCTAssertTrue(IPv6Address("::ffff:169.254.169.254")!.isUnicastLinkLocal)
+    }
+
     /// Test for private address detection.
     func testIsUnicastUniqueLocal() {
         XCTAssertFalse(IPv6Address(parts: 0, 0, 0, 0, 0, 0xffff, 0xdead, 0xbeef).isUnicastUniqueLocal)
@@ -402,7 +425,29 @@ class IPv6AddressTests: XCTestCase {
         parsed = IPv6Address("0:0:0:0:0:0:253.0.0")
         XCTAssertNil(parsed)
     }
-    
+
+    /// The parser currently exits its character loop via `else { break }` on
+    /// any unexpected character and does not validate that input was fully
+    /// consumed. Every string below has a valid IPv6 prefix followed by
+    /// arbitrary bytes and must be rejected to avoid parser-differential
+    /// attacks where this library and a downstream consumer disagree on the
+    /// meaning of the same input.
+    func testStringConstructorRejectsTrailingGarbage() {
+        XCTAssertNil(IPv6Address("2001:db8::1 and drop table"))
+        // An address parser must not accept a CIDR-shaped string.
+        XCTAssertNil(IPv6Address("2001:db8::1/64"))
+        // Mis-extracted URL authority.
+        XCTAssertNil(IPv6Address("::1]:8080"))
+        // Zone identifier: either reject, or expose it as a distinguishable
+        // property. Silently dropping means `::1` and `::1%evil` compare equal.
+        XCTAssertNil(IPv6Address("::1%eth0"))
+        XCTAssertNil(IPv6Address("::1%25eth0"))
+        // NUL terminator followed by more bytes.
+        XCTAssertNil(IPv6Address("::1\u{0}trailing"))
+        // Comma-separated address list.
+        XCTAssertNil(IPv6Address("::1,::ffff:169.254.169.254"))
+    }
+
     /// Test that the swift version creates the same IP address as the C version.
     func testEqualToPton() {
         func cDecodeIPAddress(ipString: String) -> in6_addr? {
@@ -456,6 +501,7 @@ class IPv6AddressTests: XCTestCase {
     static var allTests = [
         ("testIsUnspecified",        testIsUnspecified),
         ("testIsLoopback",           testIsLoopback),
+        ("testIPv4MappedClassification", testIPv4MappedClassification),
         ("testIsUnicastUniqueLocal", testIsUnicastUniqueLocal),
         ("testIsUnicastLinkLocal",   testIsUnicastLinkLocal),
         ("testIsUnicastGlobal",      testIsUnicastGlobal),
@@ -467,6 +513,7 @@ class IPv6AddressTests: XCTestCase {
         ("testStringConversion",     testStringConversion),
         ("testEqualityOperators",    testEqualityOperators),
         ("testStringConstructor",    testStringConstructor),
+        ("testStringConstructorRejectsTrailingGarbage", testStringConstructorRejectsTrailingGarbage),
         ("testEqualToPton",          testEqualToPton),
         ("testPhysicalProperties",   testPhysicalProperties)
     ]


### PR DESCRIPTION
## Summary

  - **CIDR types & membership testing**: new `IPv4CIDR` / `IPv6CIDR` structs pre-compute the masked network at construction so `address.isIncluded(in:)` is a
  single bitwise compare with no parsing. Closes #3.
  - **API modernisation with backwards compatibility**: added unlabeled `init(_:)` overloads for `IPv4Address([UInt8])`, `IPv4Address(UInt32)`,
  `UInt32(IPv4Address)`. Old `fromOctets:` / `fromUInt32:` / `fromIPv4Address:` callers keep working through deprecated shims. `Hashable` added to both address
  types.
  - **IPv6 parser hardening**: the parser now rejects trailing garbage (`::1/64`, `::1 extra`, `::1]:8080`, `::1%eth0`, NUL-terminated strings) instead of
  silently truncating — closes a parser-differential bypass class. Also fixes a pre-existing off-by-one in the IPv4-quad path that caused `::ffff:10.0.0.1` to
  parse as `::ffff:0.0.0.1`.
  - **Dual-stack classification**: `IPv6Address.isLoopback` / `isUnspecified` / `isUnicastUniqueLocal` / `isUnicastLinkLocal` now recognise the IPv4-mapped form
  `::ffff:X.X.X.X`. Prevents the CVE-2021-29922 / CVE-2021-29923 class of SSRF filter bypass on dual-stack sockets.
  - **Documented bug**: `testIsGlobalNonRoutableRanges` adds failing assertions for RFC 6890 ranges `isGlobal` misses (100.64/10, 198.18/15, 192.0.0.0/24, 224/4,
   240/4, 0/8) — documents the gap without changing the existing `isGlobal` contract.

  ## Test plan

  - [x] `swift test` — 39 tests; only the 12 intentionally-failing `testIsGlobalNonRoutableRanges` assertions fail.
  - [x] `testValue` exercises the deprecated `fromOctets:` / `fromUInt32:` / `fromIPv4Address:` signatures (unchanged).
  - [x] New `testValueUnlabeledInits` exercises the new `init(_:)` overloads.
  - [x] `testIncludedIn` / `testIPv4CIDR` / `testIPv6CIDR` cover string, typed, /0, /32, /128, and invalid-input paths.
  - [x] `testStringConstructorRejectsTrailingGarbage` covers the IPv6 parser tightening.
  - [x] `testIPv4MappedClassification` covers mapped loopback, link-local, private, and unspecified.