### PR TITLE
Add GitHub Actions CI for Linux and macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: swift test (Linux)
+    runs-on: ubuntu-latest
+    container:
+      image: swift:5.10-jammy
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Cache SwiftPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/.cache/org.swift.swiftpm
+            ~/.swiftpm
+          key: ${{ runner.os }}-swift-5.10-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swift-5.10-spm-
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      - name: Build
+        run: swift build --build-tests
+
+      - name: Test
+        run: swift test --skip-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: swift test (Linux)
+  linux:
+    name: Linux (Swift 5.10)
     runs-on: ubuntu-latest
     container:
       image: swift:5.10-jammy
@@ -25,9 +25,38 @@ jobs:
             .build
             ~/.cache/org.swift.swiftpm
             ~/.swiftpm
-          key: ${{ runner.os }}-swift-5.10-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          key: linux-swift-5.10-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
           restore-keys: |
-            ${{ runner.os }}-swift-5.10-spm-
+            linux-swift-5.10-spm-
+
+      - name: Resolve dependencies
+        run: swift package resolve
+
+      - name: Build
+        run: swift build --build-tests
+
+      - name: Test
+        run: swift test --skip-build
+
+  macos:
+    name: macOS
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show Swift version
+        run: swift --version
+
+      - name: Cache SwiftPM build artifacts
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+          key: macos-spm-${{ hashFiles('Package.swift', 'Package.resolved') }}
+          restore-keys: |
+            macos-spm-
 
       - name: Resolve dependencies
         run: swift package resolve


### PR DESCRIPTION
## Summary

  - Adds `.github/workflows/ci.yml` — runs `swift build --build-tests` and `swift test` on every push to master and on every PR.
  - **Linux job**: `ubuntu-latest` with the official `swift:5.10-jammy` container, so the toolchain is pinned and reproducible.
  - **macOS job**: `macos-latest` using the runner's preinstalled Swift.
  - Caches `.build` plus the platform-appropriate SwiftPM caches (`~/.cache/org.swift.swiftpm` on Linux, `~/Library/Caches/org.swift.swiftpm` on macOS),
  keyed on `Package.swift` / `Package.resolved` hash with a loose restore-key fallback. The two platforms use different key prefixes so they don't clobber
   each other.
  - `concurrency.cancel-in-progress` cancels superseded runs on the same ref.
  - `swift test --skip-build` reuses the artifacts from the build step so cache hits skip recompilation end-to-end.

  ## Test plan

  - [ ] First run populates both caches; subsequent PR pushes show shorter build steps.
  - [ ] Both jobs go green on this PR before merging.
  - [ ] Editing `Package.swift` invalidates the cache (new key) and triggers a full rebuild; editing a `.swift` source file under an existing key restores
   the cache and does an incremental build.