### PR TITLE
Broaden isGlobal to cover all RFC 6890 non-routable ranges

### DIFF
--- a/Sources/IPAddress/IPv4Address.swift
+++ b/Sources/IPAddress/IPv4Address.swift
@@ -228,21 +228,32 @@ public struct IPv4Address: LosslessStringConvertible, Hashable {
         return (value & 0x0000FFFF) == 0x0000FEA9
     }
     
-    /// Returns `true` if the IP address is globally-routable.
+    /// Returns `true` if the IP address is globally-routable per RFC 6890 —
+    /// i.e. not in any of the special-purpose ranges (private, loopback,
+    /// link-local, CGNAT, multicast, reserved, documentation, IETF protocol
+    /// assignments, benchmarking, or "this network").
     public var isGlobal: Bool {
         return !(
-            // Unspecified Address
-            value == 0x00000000 ||
-            // Private Addresses
+            // 0.0.0.0/8 "this network" (RFC 1122) — includes the unspecified address.
+            (value & 0x000000FF) == 0x00000000 ||
+            // Private Addresses (RFC 1918)
             (value & 0x000000FF) == 0x0000000A ||
             (value & 0x0000F0FF) == 0x000010AC ||
             (value & 0x0000FFFF) == 0x0000A8C0 ||
-            // Loopback Address
+            // Loopback 127.0.0.0/8
             (value & 0x000000FF) == 0x0000007F ||
-            // Link-Local Address
+            // Link-Local 169.254.0.0/16
             (value & 0x0000FFFF) == 0x0000FEA9 ||
-            // Broadcast Address
-            value == 0xFFFFFFFF ||
+            // Carrier-grade NAT 100.64.0.0/10 (RFC 6598)
+            (value & 0x0000C0FF) == 0x00004064 ||
+            // Benchmarking 198.18.0.0/15 (RFC 2544)
+            (value & 0x0000FEFF) == 0x000012C6 ||
+            // IETF Protocol Assignments 192.0.0.0/24
+            (value & 0x00FFFFFF) == 0x000000C0 ||
+            // Multicast 224.0.0.0/4 (RFC 5771)
+            (value & 0x000000F0) == 0x000000E0 ||
+            // Reserved 240.0.0.0/4 (RFC 1112) — subsumes 255.255.255.255 broadcast.
+            (value & 0x000000F0) == 0x000000F0 ||
             // Documentation Addresses
             (value & 0x00FFFFFF) == 0x000200C0 ||
             (value & 0x00FFFFFF) == 0x006433C6 ||

--- a/Tests/IPAddressTests/IPv4AddressTests.swift
+++ b/Tests/IPAddressTests/IPv4AddressTests.swift
@@ -240,7 +240,7 @@ class IPv4AddressTests: XCTestCase {
         XCTAssertFalse(address.isGlobal)
         // 192.168.0.0/16
         address = IPv4Address(parts: 192,0,0,0)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 192,167,0,0)
         XCTAssertTrue(address.isGlobal)
         address = IPv4Address(parts: 192,169,0,0)
@@ -252,7 +252,7 @@ class IPv4AddressTests: XCTestCase {
         address = IPv4Address(parts: 192,255,0,0)
         XCTAssertTrue(address.isGlobal)
         address = IPv4Address(parts: 255,168,0,0)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 192,168,0,0)
         XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 192,168,0,1)
@@ -292,7 +292,7 @@ class IPv4AddressTests: XCTestCase {
         address = IPv4Address(parts: 170,254,0,0)
         XCTAssertTrue(address.isGlobal)
         address = IPv4Address(parts: 255,254,0,0)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 169,254,0,0)
         XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 169,254,0,1)
@@ -304,24 +304,25 @@ class IPv4AddressTests: XCTestCase {
         address = IPv4Address(parts: 169,254,255,255)
         XCTAssertFalse(address.isGlobal)
         
-        // Test that the broadcast address is not globally routable.
+        // Test that the broadcast address and surrounding reserved /
+        // zero-network blocks are not globally routable.
         //
         address = IPv4Address(parts: 0,0,0,255)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 0,0,255,0)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 0,255,0,0)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 255,0,0,0)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 255,255,255,254)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 255,255,254,255)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 255,254,255,255)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 254,255,255,255)
-        XCTAssertTrue(address.isGlobal)
+        XCTAssertFalse(address.isGlobal)
         address = IPv4Address(parts: 255,255,255,255)
         XCTAssertFalse(address.isGlobal)
         
@@ -375,10 +376,7 @@ class IPv4AddressTests: XCTestCase {
         XCTAssertFalse(address.isGlobal)
     }
 
-    /// `isGlobal` is documented as "globally-routable" — the obvious primitive
-    /// for SSRF egress filtering — but its negation list omits several RFC 6890
-    /// non-globally-routable ranges. Each assertion below should return false
-    /// once the bug is fixed.
+    /// Extra coverage for RFC 6890 ranges not exercised by `testIsGlobal`.
     func testIsGlobalNonRoutableRanges() {
         // 224.0.0.0/4 multicast. SSDP / mDNS / all-hosts are LAN-only.
         XCTAssertFalse(IPv4Address(parts: 239, 255, 255, 250).isGlobal)
@@ -398,6 +396,9 @@ class IPv4AddressTests: XCTestCase {
         XCTAssertFalse(IPv4Address(parts: 198, 19, 255, 254).isGlobal)
         // 192.0.0.0/24 IETF protocol assignments.
         XCTAssertFalse(IPv4Address(parts: 192, 0, 0, 1).isGlobal)
+        // Sanity: genuinely public addresses remain globally routable.
+        XCTAssertTrue(IPv4Address(parts: 8, 8, 8, 8).isGlobal)
+        XCTAssertTrue(IPv4Address(parts: 1, 1, 1, 1).isGlobal)
     }
 
     /// Test for multicast address detection.


### PR DESCRIPTION
Extends the negation list to include 100.64.0.0/10 (CGNAT), 198.18.0.0/15 (benchmarking), 192.0.0.0/24 (IETF protocol assignments), 224.0.0.0/4 (multicast), 240.0.0.0/4 (reserved, which subsumes the 255.255.255.255 broadcast), and 0.0.0.0/8 ("this network"). Updates the existing testIsGlobal assertions that encoded the previous narrower behaviour, and replaces the previously-failing testIsGlobalNonRoutableRanges placeholder with a test that exercises every added range and two genuinely public sanity addresses.